### PR TITLE
v2.1.0: Add favicon logo overlay on QR code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides context for AI assistants working in this repository.
 
 **Colorful QRCode** is a Chrome/Firefox browser extension (Manifest V3) that generates colorful QR codes for the current tab's URL or custom user-provided text. It uses randomly generated dark colors. All QR generation happens locally in the browser — no network requests are made.
 
-- **Version:** 2.0.0
+- **Version:** 2.1.0
 - **Author:** L3au
 - **Chrome Web Store:** Published, offline-capable
 
@@ -43,7 +43,7 @@ colorful-qrcode/
 - **Framework:** WXT (Vite-based browser extension framework)
 - **Extension API:** Manifest V3 + `browser.*` (webextension-polyfill via WXT)
 - **Package manager:** pnpm
-- **QR library:** `qrcode` (soldair, npm) — async `toDataURL` API
+- **QR library:** `qrcode` (soldair, npm) — `toCanvas` API with HiDPI support
 - **Color library:** `randomcolor` (npm)
 - **Tests:** Vitest + jsdom, v8 coverage (≥80% threshold on `src/utils/`)
 - **CI/CD:** GitHub Actions (ci.yml on PR, release.yml on push to master)
@@ -54,7 +54,8 @@ colorful-qrcode/
 The core of the extension:
 - Queries the active tab URL via `browser.tabs.query`
 - Detects localhost addresses and replaces them with the LAN IP
-- Generates QR via `QRCode.toDataURL()` with random dark color
+- Generates QR via `QRCode.toCanvas()` with random dark color and HiDPI rendering
+- Overlays the current site's favicon as a center logo (uses error correction level H)
 - Two UI modes: **view mode** (QR image) and **edit mode** (textarea)
 - Enter toggles modes; Shift+Enter/Ctrl+Enter inserts newlines
 
@@ -89,11 +90,15 @@ To load the built extension manually:
 ## QR Code Configuration
 
 ```typescript
-const dataUrl = await QRCode.toDataURL(text, {
-  width: 240,
+await QRCode.toCanvas(canvas, text, {
+  width: renderSize,        // QR_SIZE * devicePixelRatio
+  margin: 0,
   color: { dark: color, light: '#ffffff' },
+  errorCorrectionLevel: 'H', // only when favicon logo is shown
 });
 ```
+
+When a favicon is available, the site logo (48×48px) is drawn at the center of the QR code with a white background pad. Error correction level H (~30%) ensures scannability despite the logo overlay. If the data is too long for level H, the logo is dropped and the default level M is used instead.
 
 ## Branch Conventions
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Chrome/Firefox extension that generates colorful QR codes for the current page
 ## Features
 
 - **Colorful by default** — each QR code uses a random dark color
+- **Center logo** — the current site's favicon is overlaid at the center of the QR code
+- **HiDPI ready** — crisp rendering on Retina and high-DPI displays
 - **Works offline** — all generation happens locally, no network requests
 - **Localhost detection** — automatically replaces `localhost` with your LAN IP so mobile devices can reach it (e.g. `http://localhost:3000` → `http://192.168.1.5:3000`)
 - **Editable** — click the QR code (or press Enter) to type custom text, then press Enter again to generate
@@ -14,6 +16,8 @@ A Chrome/Firefox extension that generates colorful QR codes for the current page
 ## Install
 
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/nenelpicledkmgnlaibhjkjobffpjoan/)
+- [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/colorful-qrcode/)
+- [GitHub Releases](https://github.com/L3au/colorful-qrcode/releases) — download `.zip` and load manually
 - Or build from source: `pnpm install && pnpm build`, then load `.output/chrome-mv3/` as an unpacked extension
 
 ## Development

--- a/WEBSTORE.md
+++ b/WEBSTORE.md
@@ -13,6 +13,7 @@ Colorful QRCode generates a unique, colorful QR code every time you click the ic
 Features:
 • Instant QR code for the current page URL
 • Random dark color on every open — always unique
+• Site favicon displayed as a center logo on the QR code
 • Click the QR code to edit text and generate a custom code
 • Localhost URLs are automatically replaced with your LAN IP — perfect for testing on mobile devices
 • Works completely offline — no data leaves your browser
@@ -37,6 +38,7 @@ Colorful QRCode generates a unique, colorful QR code every time you click the ic
 Features:
 • Instant QR code for the current page URL
 • Random dark color on every open — always unique
+• Site favicon displayed as a center logo on the QR code
 • Click the QR code to edit text and generate a custom code
 • Localhost URLs are automatically replaced with your LAN IP — perfect for testing on mobile devices
 • Works completely offline — no data leaves your browser

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colorful-qrcode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/entrypoints/popup/main.ts
+++ b/src/entrypoints/popup/main.ts
@@ -2,17 +2,69 @@ import QRCode from 'qrcode';
 import randomColor from 'randomcolor';
 import { getLocalIPs, getHostname, LOCAL_HOSTS, replaceLocalhost } from '../../utils/localIp';
 
+const QR_SIZE = 240;
+const LOGO_SIZE = 48;
+
 const qr = document.getElementById('qr')!;
 const txt = qr.querySelector<HTMLTextAreaElement>('textarea')!;
 let img: HTMLImageElement | null = null;
 let localIp: string | undefined;
+let faviconUrl: string | undefined;
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = reject;
+    image.src = src;
+  });
+}
 
 async function renderQR(text: string, color: string): Promise<void> {
-  const dataUrl = await QRCode.toDataURL(text, {
-    width: 240,
+  const dpr = window.devicePixelRatio || 1;
+  const renderSize = Math.round(QR_SIZE * dpr);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = renderSize;
+  canvas.height = renderSize;
+
+  const opts = {
+    width: renderSize,
     margin: 0,
     color: { dark: color, light: '#ffffff' },
-  });
+  };
+
+  let showLogo = !!faviconUrl;
+
+  if (showLogo) {
+    try {
+      await QRCode.toCanvas(canvas, text, { ...opts, errorCorrectionLevel: 'H' as const });
+    } catch {
+      // Data too long for level H — fall back to default without logo
+      showLogo = false;
+      await QRCode.toCanvas(canvas, text, opts);
+    }
+  } else {
+    await QRCode.toCanvas(canvas, text, opts);
+  }
+
+  if (showLogo && faviconUrl) {
+    try {
+      const logo = await loadImage(faviconUrl);
+      const ctx = canvas.getContext('2d')!;
+      const x = (renderSize - LOGO_SIZE) / 2;
+      const y = (renderSize - LOGO_SIZE) / 2;
+      const pad = Math.round(2 * dpr);
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(x - pad, y - pad, LOGO_SIZE + pad * 2, LOGO_SIZE + pad * 2);
+      ctx.drawImage(logo, x, y, LOGO_SIZE, LOGO_SIZE);
+    } catch {
+      // Favicon failed to load — show QR without logo
+    }
+  }
+
+  const dataUrl = canvas.toDataURL();
 
   if (!img) {
     img = document.createElement('img');
@@ -54,20 +106,16 @@ async function showMain(url: string, color: string) {
 
 async function init() {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
-  const url = tabs[0]?.url ?? '';
+  const tab = tabs[0];
+  const url = tab?.url ?? '';
 
   txt.value = url;
+  faviconUrl = tab?.favIconUrl ?? undefined;
+  qr.classList.add('loading');
 
   const isLocalhost = LOCAL_HOSTS.includes(getHostname(url) ?? '');
-
-  if (isLocalhost) {
-    qr.classList.add('loading');
-  }
-
   const ips = isLocalhost ? await getLocalIPs() : [];
   const color = randomColor({ luminosity: 'dark' });
-
-  qr.classList.remove('loading');
 
   if (ips.length > 0) {
     localIp = ips[0];
@@ -77,6 +125,7 @@ async function init() {
   txt.value = text;
 
   await renderQR(text, color);
+  qr.classList.remove('loading');
 
   document.addEventListener('keypress', (e) => {
     if (e.key !== 'Enter') return;

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'wxt';
 export default defineConfig({
   manifest: {
     name: 'Colorful QRCode',
-    version: '2.0.0',
+    version: '2.1.0',
     description: 'simple & colorful QR code generator',
     permissions: ['tabs'],
     action: {


### PR DESCRIPTION
## Summary

- Overlay the current site's favicon (48px) at the center of the QR code using canvas
- HiDPI rendering via `devicePixelRatio` scaling
- Error correction level H when logo is shown; falls back to default M on long data
- Show loading spinner until QR is fully rendered
- Add Firefox Add-ons and GitHub Releases links to README
- Bump version to 2.1.0

Inspired by #1 — reimplemented for the TypeScript + WXT codebase.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 9/9 tests pass
- [x] Manual test: open popup on a site with favicon, verify logo appears at center
- [x] Manual test: open popup on a site without favicon, verify plain QR code
- [x] Manual test: verify long URLs fall back to QR without logo
- [x] Scan QR codes to confirm readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)