### PR TITLE
Skip release when version tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,15 @@ jobs:
       - run: pnpm zip:firefox
       - id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - id: check_tag
+        run: |
+          if git ls-remote --tags origin "v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
       - uses: softprops/action-gh-release@v2
+        if: steps.check_tag.outputs.exists == 'false'
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: .output/*.zip


### PR DESCRIPTION
## Summary
- Add a tag existence check before the `softprops/action-gh-release` step in the release workflow
- If the version tag already exists on the remote, the release step is skipped
- Fixes "Cannot delete asset from an immutable release" error when non-version-bump PRs merge to master

## Test plan
- [x] Non-version-bump PR merge → release job skips the gh-release step
- [ ] Version-bump PR merge → release job creates a new release as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)